### PR TITLE
Refresh apt cache before install

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,7 @@
 --- 
 
 - name: Install packages with apt
-  apt: name={{ item }} state=present
+  apt: name={{ item }} state=present update_cache=true
   with_items:
     - python-pip
     - python-dev


### PR DESCRIPTION
This avoids lots of errors on install with 404 packages
