### PR TITLE
Add uwsgi_graphite_extraopts to configure uwsgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ server {
 }
 ```
 
+Alternatively, you can define `uwsgi_graphite_extraopts` with additional uwsgi configuration, which can e.g. enable http on port 8080 or add basic auth:
+```yaml
+uwsgi_graphite_extraopts:
+  - option: http
+    value: "{{ ansible_default_ipv4.address }}:8080"
+  - option: plugins
+    value: router_basicauth
+  - option: route
+    value: "^/ basicauth:myRealm,foo:bar"
+```
+
 Role Variables
 --------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,3 +96,6 @@ graphite_aggregator_use_flow_control:           true
 graphite_aggregator_use_whitelist:              false
 #graphite_aggregator_user:
 graphite_aggregator_write_back_frequency:       0
+
+# Optional extra options for uwsgi_graphite.ini
+uwsgi_graphite_extraopts: []

--- a/templates/uwsgi_graphite.ini.j2
+++ b/templates/uwsgi_graphite.ini.j2
@@ -8,3 +8,6 @@ module = wsgi:application
 {% if ansible_os_family == "RedHat" %}
 pidfile = /run/uwsgi/graphite/pid
 {% endif %}
+{% for opts in uwsgi_graphite_extraopts %}
+{{ opts.option }}={{ opts.value }}
+{% endfor %}


### PR DESCRIPTION
Defining this variable you can add any custom uwsgi configuration to uwsgi_graphite.ini, such as e.g. enabling http on port 8080 or enabling http auth:

```
uwsgi_graphite_extraopts: |
  http = {{ ansible_default_ipv4.address }}:8080
  plugins = router_basicauth
  route = ^/ basicauth:myRealm,foo:bar
```
