### PR TITLE
enable uwsgi and carbon-cache service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,3 +76,9 @@
 
 - name: Remove temp file
   file: path=/tmp/createsuperuser.py state=absent
+
+- name: Enable uwsgi service
+  service: name=uwsgi enabled=yes
+
+- name: Enable carbon-cache service
+  service: name=carbon-cache enabled=yes


### PR DESCRIPTION
- so both get started on reboot
- at least on Ubuntu uwsgi is enabled by default
