### PR TITLE
Use proper variable reference for pip installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Setup graphite with pip
   pip: name={{ item }} state=present
-  with_items: graphite_install_requirements[graphite_install_version]
+  with_items: "{{ graphite_install_requirements[graphite_install_version] }}"
   environment:
     PYTHONPATH: "{{ graphite_install_path }}/lib:{{ graphite_install_path }}/webapp"
   notify: restart carbon-cache


### PR DESCRIPTION
I get the following error when running this role:

```
TASK [ansible-graphite : Setup graphite with pip] ******************************
failed: [graphite] (item=graphite_install_requirements[graphite_install_version]) => {"cmd": "/usr/bin/pip2 install graphite_install_requirements[graphite_install_version]", "failed": true, "item": "graphite_install_requirements[graphite_install_version]", "msg": "stdout: Collecting graphite-install-requirements[graphite_install_version]\n\n:stderr: You are using pip version 7.1.0, however version 9.0.1 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n  Could not find a version that satisfies the requirement graphite-install-requirements[graphite_install_version] (from versions: )\nNo matching distribution found for graphite-install-requirements[graphite_install_version]\n"}
```

This PR uses the proper variable substitution.