### PR TITLE
Bare variable names are no longer accepted.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Setup graphite with pip
   pip: name={{ item }} state=present
-  with_items: graphite_install_requirements[graphite_install_version]
+  with_items: "{{ graphite_install_requirements[graphite_install_version] }}"
   environment:
     PYTHONPATH: "{{ graphite_install_path }}/lib:{{ graphite_install_path }}/webapp"
   notify: restart carbon-cache


### PR DESCRIPTION
When specifying complex args as variable, the variable must use the full jinja2 syntax. Bare variable names are no longer accepted.

#19 is also fixed.