### PR TITLE
Remove support for old insecure Ansible versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ env:
   global:
     - CONTAINER_IMAGES="images:centos/6 images:centos/7 images:debian/jessie images:debian/stretch ubuntu:14.04 ubuntu:16.04"
   matrix:
-    - ANSIBLE_VERSIONS="1.8.4"
-    - ANSIBLE_VERSIONS="1.9.6"
     - ANSIBLE_VERSIONS="2.1.6"
+    - ANSIBLE_VERSIONS="2.2.3"
     - ANSIBLE_VERSIONS="latest"
 
 install:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.1.4
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 


### PR DESCRIPTION
There are several security vulnerabilities in older Ansible versions,
for example 2.0, 1.9 and 1.8 (and probably older).

This commit removes the tests for anything older than the 2.2 release.
min_ansible_version is also bumped to 2.1.4, this version was chosen
because it contains the fix for CVE-2016-9587.