### PR TITLE
Update to graphite version 1.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
     - ANSIBLE_VERSIONS="2.2.3" ANSIBLE_EXTRA_VARS_LIST="version=1.0.2"
     - ANSIBLE_VERSIONS="latest" ANSIBLE_EXTRA_VARS_LIST="version=1.0.2"
 
+    - ANSIBLE_VERSIONS="2.1.6" ANSIBLE_EXTRA_VARS_LIST="version=1.1.3"
+    - ANSIBLE_VERSIONS="2.2.3" ANSIBLE_EXTRA_VARS_LIST="version=1.1.3"
+    - ANSIBLE_VERSIONS="latest" ANSIBLE_EXTRA_VARS_LIST="version=1.1.3"
+
 install:
   # Download ansible-role-tester and setup the enviroment
   - wget https://raw.githubusercontent.com/nsg/ansible-role-tester/master/test.sh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-graphite_install_version: 1.0.2
+graphite_install_version: 1.1.3
 
 graphite_user: graphite
 graphite_secret_key: UNSAFE_DEFAULT
@@ -132,3 +132,27 @@ graphite_install_requirements:
     - graphite-web==1.0.2
     - carbon==1.0.2
     - whisper==1.0.2
+  1.1.3:
+    - attrs==17.4.0
+    - Automat==0.6.0
+    - cachetools==2.0.1
+    - cairocffi==0.8.0
+    - carbon==1.1.3
+    - cffi==1.11.5
+    - constantly==15.1.0
+    - Django==1.11.12
+    - django-tagging==0.4.3
+    - graphite-web==1.1.3
+    - hyperlink==18.0.0
+    - idna==2.6
+    - incremental==17.5.0
+    - pycparser==2.18
+    - pyparsing==2.2.0
+    - pytz==2018.4
+    - scandir==1.7
+    - six==1.11.0
+    - Twisted==18.4.0
+    - txAMQP==0.8.2
+    - urllib3==1.22
+    - whisper==1.1.3
+    - zope.interface==4.5.0

--- a/tests/pre.yml
+++ b/tests/pre.yml
@@ -13,6 +13,7 @@
     - name: Debian | Install a few packages for the tests
       apt: name={{ item }}
       with_items:
-        - netcat
         - curl
+        - file
+        - netcat
       when: ansible_os_family == "Debian"


### PR DESCRIPTION
The latest version is 1.1.3 - the pip package list
is derived from a 'pip freeze' in a virtualenv with
the graphite-web, carbon and whisper packages
installed in it. This ensures that the packages and
everything they depend on is always the same when
deploying.