### PR TITLE
Allow tuning of uwsgi process and carbon-cache fd limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@ graphite_install_version: 1.1.3
 
 graphite_user: graphite
 graphite_secret_key: UNSAFE_DEFAULT
-graphite_open_files_limit: 4096
 graphite_time_zone: UTC
 
 graphite_admin_date_joined: "2014-07-21T10:11:17.464"
@@ -13,6 +12,8 @@ graphite_admin_last_name: ""
 graphite_admin_last_login: "2014-07-21T10:11:17.464"
 graphite_admin_username: admin
 graphite_admin_password: admin
+
+graphite_service_carbon_open_files_limit: 4096
 
 # The default is "60s:1d" (1 day data), this will keep data for 5 years.
 # If you log a lot of data, you may need to restrict this to a shorter time.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ graphite_install_version: 1.1.3
 
 graphite_user: graphite
 graphite_secret_key: UNSAFE_DEFAULT
+graphite_open_files_limit: 4096
 graphite_time_zone: UTC
 
 graphite_admin_date_joined: "2014-07-21T10:11:17.464"
@@ -108,6 +109,7 @@ graphite_aggregator_write_back_frequency: 0
 
 # Optional extra options for uwsgi_graphite.ini
 uwsgi_graphite_extraopts: []
+uwsgi_graphite_processes: 2
 uwsgi_graphite_socket: '127.0.0.1:3031'
 
 graphite_install_path: "/opt/graphite"

--- a/templates/carbon_service_systemd.j2
+++ b/templates/carbon_service_systemd.j2
@@ -10,7 +10,7 @@ Restart=on-failure
 User={{ graphite_user }}
 Group={{ graphite_user }}
 NoNewPrivileges=true
-LimitNOFILE={{ graphite_open_files_limit }}
+LimitNOFILE={{ graphite_service_carbon_open_files_limit }}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/carbon_service_systemd.j2
+++ b/templates/carbon_service_systemd.j2
@@ -10,6 +10,7 @@ Restart=on-failure
 User={{ graphite_user }}
 Group={{ graphite_user }}
 NoNewPrivileges=true
+LimitNOFILE={{ graphite_open_files_limit }}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/debian_carbon_service.j2
+++ b/templates/debian_carbon_service.j2
@@ -14,7 +14,7 @@ set -e
 test -x {{ graphite_install_path }}/bin/carbon-cache.py || exit 0
 
 umask 022
-ulimit -n {{ graphite_open_files_limit }}
+ulimit -n {{ graphite_service_carbon_open_files_limit }}
 
 . /lib/lsb/init-functions
 

--- a/templates/debian_carbon_service.j2
+++ b/templates/debian_carbon_service.j2
@@ -14,6 +14,7 @@ set -e
 test -x {{ graphite_install_path }}/bin/carbon-cache.py || exit 0
 
 umask 022
+ulimit -n {{ graphite_open_files_limit }}
 
 . /lib/lsb/init-functions
 

--- a/templates/uwsgi_graphite.ini.j2
+++ b/templates/uwsgi_graphite.ini.j2
@@ -1,5 +1,5 @@
 [uwsgi]
-processes = 2
+processes = {{ uwsgi_graphite_processes }}
 socket = {{ uwsgi_graphite_socket }}
 gid = {{ graphite_user }}
 uid = {{ graphite_user }}

--- a/tests/post.yml
+++ b/tests/post.yml
@@ -28,6 +28,9 @@
         - uwsgi
         - nginx
 
+    - name: Make sure that the carbon-cache process has the expected open file limit
+      shell: "test $(awk '/^Max open files/ { print $4 }' /proc/$(pidof -x carbon-cache.py)/limits) -eq 4096"
+
     - name: Get sample config file parameters
       shell: "grep -vE '^#' /opt/graphite/conf/carbon.conf.example | awk -F '=' '/=/{ print $1 }'"
       register: carbon_conf_example_default_params


### PR DESCRIPTION
This commit aims to expose the UWSGI process count and carbon-cache's open file descriptor ulimit via playbook variables. It also adds a simple test for the ulimit change.

I welcome feedback on variable naming, especially for `graphite_open_files_limit`.  `graphite_cache_open_files_limit` seemed more appropriate, as this limit only affects carbon-cache, but a quick scan looks like the `carbon_cache_*` vars are all named for the related settings in `carbon.conf`.

Thanks for taking a look.