### PR TITLE
Fix boolean conditionals because of deprecation in ansible 2.12

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,12 +2,12 @@
 
 - name: restart carbon-cache
   service: name=carbon-cache state=restarted
-  when: graphite_enable_carbon_cache
+  when: graphite_enable_carbon_cache == true
 
 - name: restart carbon-relay
   service: name=carbon-relay state=restarted
-  when: graphite_enable_carbon_relay
+  when: graphite_enable_carbon_relay == true
 
 - name: restart uwsgi
   service: name=uwsgi state=restarted
-  when: graphite_enable_uwsgi
+  when: graphite_enable_uwsgi == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,16 +117,16 @@
   service:
     name: uwsgi
     enabled: yes
-  when: graphite_enable_uwsgi
+  when: graphite_enable_uwsgi == true
 
 - name: Enable carbon-cache service
   service:
     name: carbon-cache
     enabled: yes
-  when: graphite_enable_carbon_cache
+  when: graphite_enable_carbon_cache == true
 
 - name: Enable carbon-relay service
   service:
     name: carbon-relay
     enabled: yes
-  when: graphite_enable_carbon_relay
+  when: graphite_enable_carbon_relay == true


### PR DESCRIPTION
Fix boolean conditionals for future deprecation in Ansible 2.12 because of this warning:
[DEPRECATION WARNING]: evaluating graphite_enable_uwsgi as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also
 see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in
 ansible.cfg.